### PR TITLE
Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,32 @@
 # Hello WASI HTTP!
 
-This is a simple tutorial to get started with WASI HTTP using the
-`wasmtime serve` command in [Wasmtime] 18.0. It runs an HTTP server and
-forwards requests to a Wasm component via the [WASI HTTP] API.
+This is a simple tutorial to get started with WASI HTTP using the `wasmtime serve` command introduced in [Wasmtime] 18.0.
+It runs an HTTP server and forwards requests to a Wasm component via the [WASI HTTP] API.
 
 [Wasmtime]: https://wasmtime.dev
 [WASI HTTP]: https://github.com/WebAssembly/wasi-http/
 
-The WASI HTTP API is now stable, and part of WASI Preview 2.
+The WASI HTTP API is now stable, and part of WASI 0.2.
 
 So without further ado...
 
 ## Let's go!
 
-First, [install `cargo component`](https://github.com/bytecodealliance/cargo-component#requirements),
-at least version `0.13.2`, which is a tool for building Wasm components implemented in
-Rust. (See [here] for information about building Wasm components from other
-languages too!)
+First, [install `cargo-component`](https://github.com/bytecodealliance/cargo-component#requirements) (at least,
+`cargo-component` `0.13.2`). `cargo-component` is a tool for building Wasm components implemented in Rust. For more
+information on building Wasm components from different languages, check [here]!
 
 [here]: https://component-model.bytecodealliance.org/language-support.html
 
-With that, build the Wasm component from the source in this repository:
+With that, build the Wasm component from source in this repository:
 ```sh
-$ cargo component build
-   Compiling hello-wasi-http v0.0.0 (/home/wasm/hello-wasi-http)
-    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
-    Creating component /home/wasm/hello-wasi-http/target/wasm32-wasi/debug/hello_wasi_http.wasm
-$
+cargo component build
 ```
 
-This builds a Wasm component, `target/wasm32-wasi/debug/hello_wasi_http.wasm`.
+This builds a Wasm component at `target/wasm32-wasip1/debug/hello_wasi_http.wasm`.
 
-To run it, we'll need at least Wasmtime 18.0.0. Installation instructions are
-on [wasmtime.dev]:
+To run it, we'll need at least Wasmtime `18.0`. You can install it on Linux or macOS with the command below (for other 
+platforms, see [wasmtime.dev]).
 
 ```sh
 $ curl https://wasmtime.dev/install.sh -sSf | bash
@@ -40,9 +34,9 @@ $ curl https://wasmtime.dev/install.sh -sSf | bash
 
 [wasmtime.dev]: https://wasmtime.dev/
 
-Then run in your terminal:
+Then, run in your terminal:
 ```sh
-$ cargo component serve
+$ cargo component serve # or, wasmtime serve target/wasm32-wasip1/debug/hello_wasi_http.wasm
 ```
 This starts up an HTTP server that, by default, listens on `0.0.0.0:8080`.
 
@@ -54,84 +48,68 @@ Hello, wasi:http/proxy world!
 
 ## Optimizing!
 
-The above uses a debug build; to make a component that runs faster, build
-with `cargo component build --release`.
+The above uses a `debug` build. To make a component that runs faster, build with `cargo component build --release`.
 
-It's also worth making sure you have a release build of Wasmtime; if you
-installed it from the instructions above with wasmtime.dev, you're good.
+It's also worth making sure you have a release build of Wasmtime; if you installed it from the instructions above
+with wasmtime.dev, you're good.
 
-Wasmtime has several tuning options that can improve performance in different
-situations&mdash;pass `-O help` for a list&mdash;but one that's especially
-useful here is `-O pooling-allocator`.
+Wasmtime has several tuning options that can improve performance in different situations — pass `-O help` for a
+list. One that's especially useful here is `-O pooling-allocator`.
 
 ## Notes
 
-`wasmtime serve` uses the [proxy] world, which is a specialized world just for
-accepting requests and producing responses. One interesting thing about the proxy
-world is that it doesn't have a filesystem or network API. If you add code to the
-example that tries to access files or network sockets, it won't be able to build,
-because those APIs are not available in this world. This allows proxy components
-to run in many different places, including specialized serverless environments
-which may not provide traditional filesystem and network access.
+`wasmtime serve` uses the [proxy] world, which is a specialized world just for accepting requests and producing
+responses. One interesting thing about the proxy world is that it doesn't have a filesystem or network API. If you add
+code to the example that tries to access files or network sockets, it won't be able to build, because those APIs are
+not available in this world. This allows proxy components to run in many different places, including specialized
+serverless environments which may not provide traditional filesystem and network access.
 
-But what if you do want to have it serve some files? One option will be to use
-[WASI-Virt](https://github.com/bytecodealliance/WASI-Virt), which is a tool
-that can bundle a filesystem with a component.
+But, what if you do want to have it serve some files? One option will be to use 
+[WASI-Virt](https://github.com/bytecodealliance/WASI-Virt), which is a tool that can bundle a filesystem with a 
+component.
 
-Another option is to use a custom world. The proxy world is meant to be able
-to run in many different environments, but if you know your environment and
-you know it has a filesystem, you could create your own world, by including
-both the "wasi:http/proxy" and "wasi:filesystem/types" or any other APIs you want
-the Wasm to be able to access. This would require a custom embedding of Wasmtime,
-as it wouldn't run under plain `wasmtime serve`, so it's a little more work to
-set up.
+Another option is to use a custom `world`. The proxy world is meant to be able to run in many different environments,
+but if you know your environment, and you know it has a filesystem, you could create your own world, by including both
+the `"wasi:http/proxy"` and `"wasi:filesystem/types"` or any other APIs you want the Wasm to be able to access. This
+would require a custom embedding of Wasmtime, as it wouldn't run under plain `wasmtime serve`, so it's a little more
+work to set up.
 
-In the future, we expect to see standard worlds emerge that combine WASI HTTP
-with many other APIs, such as [wasi-cloud-core].
+In the future, we expect to see standard `world`s emerge that combine WASI HTTP with many other APIs, such as
+[wasi-cloud-core].
 
-[wasi-cloud-core]: https://github.com/WebAssembly/wasi-cloud-core
-
-If you're interested in tutorials for any of these options, please reach out
-and say hi!
+If you're interested in tutorials for any of these options, please reach out and say hi!
 
 [proxy]: https://github.com/WebAssembly/wasi-http/blob/main/wit/proxy.wit
+[wasi-cloud-core]: https://github.com/WebAssembly/wasi-cloud-core
 
 ## Creating this repo
 
-Here are my notes on how I created this repository, in case you're interested
-in recreating it.
+Here are my notes on how I created this repository, in case you're interested in recreating it.
 
-Run `cargo-component new --proxy --lib` to create a new project:
+To create a new project, run:
 
 ```sh
-$ cargo component new --reactor hello-wasi-http
-     Created binary (application) `hello-wasi-http` package
-     Updated manifest of package `hello-wasi-http`
-   Generated source file `src/main.rs`
+$ cargo component new --proxy --lib hello-wasi-http
 $ cd hello-wasi-http
 ```
 
-Copy the `wit` directory from Wasmtime 18.0.0, to ensure that we're using the
-same version of the API that Wasmtime is built with:
+Copy the `wit` directory from your version of  Wasmtime, to ensure that we're using the same version of the API that
+Wasmtime is built with (e.g., for Wasmtime 18.0.0: https://github.com/bytecodealliance/wasmtime/tree/release-18.0.0).
 
-<https://github.com/bytecodealliance/wasmtime/tree/release-18.0.0>
+Then, I manually trimmed the filesystem and sockets dependencies out.
 
-I then manually trimmed the filesystem and sockets dependencies out.
+In the future, we'll have wit dependencies stored in a registry, which will make this all much easier.
 
-In the future, we'll have wit dependencies stored in a registry, which will
-make this all much easier.
-
-I derived `src/lib.rs` from Wasmtime's
-`crates/test-programs/src/bin/api_proxy.rs` contents on the `main` branch,
+I derived `src/lib.rs` from Wasmtime's `crates/test-programs/src/bin/api_proxy.rs` contents on the `main` branch,
 adapted it to work with cargo component, in particular by adding:
 
 ```rust
 cargo_component_bindings::generate!();
 ```
 
-and renaming the `T` type to `Component`, which the bindings expect.
+Then, renamed the `T` type to `Component`, which the bindings expect.
 
-Add dependencies:
+Finally, add dependencies:
 ```
 $ cargo component add --target --path wit/deps/clocks wasi:clocks
 $ cargo component add --target --path wit/deps/io wasi:io
@@ -139,8 +117,8 @@ $ cargo component add --target --path wit/deps/random wasi:random
 $ cargo component add --target --path wit/deps/cli wasi:cli
 $ cargo component add --target --path wit/deps/logging wasi:logging
 ```
-These don't all actually get used in this tutorial, but they're currently
-needed because of some of the interfaces we copied in from the Wasmtime tree
-reference them.
 
-TODO: I should also make a api_proxy_streaming.rs version to show streaming.
+These don't all actually get used in this tutorial, but they're currently needed because of some of the interfaces we
+copied in from the Wasmtime tree reference them.
+
+> TODO: I should also make a `api_proxy_streaming.rs` version to show streaming.

--- a/README.md
+++ b/README.md
@@ -12,21 +12,22 @@ So without further ado...
 
 ## Let's go!
 
-First, [install `cargo-component`](https://github.com/bytecodealliance/cargo-component#requirements) (at least,
-`cargo-component` `0.13.2`). `cargo-component` is a tool for building Wasm components implemented in Rust. For more
+First, [install `cargo-component`](https://github.com/bytecodealliance/cargo-component#requirements) (version 0.13.2 or later). `cargo-component` is a tool for building Wasm components implemented in Rust. For more
 information on building Wasm components from different languages, check [here]!
 
 [here]: https://component-model.bytecodealliance.org/language-support.html
 
 With that, build the Wasm component from source in this repository:
 ```sh
-cargo component build
+$ cargo component build
+  Compiling hello-wasi-http v0.0.0 (/home/wasm/hello-wasi-http)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.01s
+    Creating component target/wasm32-wasip1/debug/hello_wasi_http.wasm
 ```
 
 This builds a Wasm component at `target/wasm32-wasip1/debug/hello_wasi_http.wasm`.
 
-To run it, we'll need at least Wasmtime `18.0`. You can install it on Linux or macOS with the command below (for other 
-platforms, see [wasmtime.dev]).
+To run it, we'll need at least Wasmtime `18.0`. Installation instructions are on [wasmtime.dev]. For example, on Linux or macOS, use the command below:
 
 ```sh
 $ curl https://wasmtime.dev/install.sh -sSf | bash
@@ -36,7 +37,7 @@ $ curl https://wasmtime.dev/install.sh -sSf | bash
 
 Then, run in your terminal:
 ```sh
-$ cargo component serve # or, wasmtime serve target/wasm32-wasip1/debug/hello_wasi_http.wasm
+$ cargo component serve
 ```
 This starts up an HTTP server that, by default, listens on `0.0.0.0:8080`.
 
@@ -53,7 +54,7 @@ The above uses a `debug` build. To make a component that runs faster, build with
 It's also worth making sure you have a release build of Wasmtime; if you installed it from the instructions above
 with wasmtime.dev, you're good.
 
-Wasmtime has several tuning options that can improve performance in different situations — pass `-O help` for a
+Wasmtime has several tuning options that can improve performance in different situations—pass `-O help` for a
 list. One that's especially useful here is `-O pooling-allocator`.
 
 ## Notes
@@ -90,6 +91,9 @@ To create a new project, run:
 
 ```sh
 $ cargo component new --proxy --lib hello-wasi-http
+    Created binary (application) `hello-wasi-http` package
+    Updated manifest of package `hello-wasi-http`
+    Generated source file `src/main.rs`
 $ cd hello-wasi-http
 ```
 
@@ -107,7 +111,7 @@ adapted it to work with cargo component, in particular by adding:
 cargo_component_bindings::generate!();
 ```
 
-Then, renamed the `T` type to `Component`, which the bindings expect.
+Then, I renamed the `T` type to `Component`, which the bindings expect.
 
 Finally, add dependencies:
 ```


### PR DESCRIPTION
- Changes "WASI Preview 2" mention to "WASI 0.2".
- Changes `wasm32-wasi` in `target` path to `wasm32-wasip1`.
- Changed to actually use `--proxy --lib`  flags of `cargo-component` instead of `--reactor`.
- Small writting changes here and there.